### PR TITLE
docs: Fix grammar mistake in docs

### DIFF
--- a/docs/docs/get_started/quickstart.mdx
+++ b/docs/docs/get_started/quickstart.mdx
@@ -194,7 +194,7 @@ Prompt templates convert raw user input to better input to the LLM.
 ```python
 from langchain_core.prompts import ChatPromptTemplate
 prompt = ChatPromptTemplate.from_messages([
-    ("system", "You are world class technical documentation writer."),
+    ("system", "You are a world class technical documentation writer."),
     ("user", "{input}")
 ])
 ```


### PR DESCRIPTION
Description: Changed "You are" to "You are a". Grammar issue.
Dependencies: None